### PR TITLE
another typo discovered in template file

### DIFF
--- a/iiifcollectionbrowse/blueprint/templates/collection_list.html
+++ b/iiifcollectionbrowse/blueprint/templates/collection_list.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block body %}\
+{% block body %}
 
 {% if cdesc %}
     <section class="description" role="complementary">


### PR DESCRIPTION
- removed \ that was following start of body block